### PR TITLE
Fix route v8 multiple via points

### DIFF
--- a/herepy/routing_api.py
+++ b/herepy/routing_api.py
@@ -448,7 +448,7 @@ class RoutingApi(HEREApi):
         via_keys = []
         if via:
             for i, v in enumerate(via):
-                key = str.format("{0}{1}", "via", i)
+                key = str.format("{0}{1}_", "via", i)
                 via_keys.append(key)
                 data[key] = str.format("{0},{1}", v[0], v[1])
         if departure_time:

--- a/tests/test_routing_api.py
+++ b/tests/test_routing_api.py
@@ -1179,3 +1179,29 @@ class RoutingApiTest(unittest.TestCase):
                 truck={"shippedHazardousGoods": ["explosive", "gas"]},
                 scooter={"allowHighway": "true"},
             )
+
+    @responses.activate
+    def test_route_v8_multiple_via_points(self):
+        with codecs.open(
+            "testdata/models/routing_v8_response.json", mode="r", encoding="utf-8"
+        ) as f:
+            expectedResponse = f.read()
+        responses.add(
+            responses.GET,
+            "https://router.hereapi.com/v8/routes",
+            expectedResponse,
+            status=200,
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"via": ["41.9339,-87.9021"] * 11}, strict_match=False
+                )
+            ],
+        )
+        response = self._api.route_v8(
+            transport_mode=herepy.RoutingTransportMode.car,
+            origin=[41.9798, -87.8801],
+            destination=[41.9043, -87.9216],
+            via=[[41.9339, -87.9021]] * 11,
+        )
+        self.assertTrue(response)
+        self.assertIsInstance(response, herepy.RoutingResponseV8)

--- a/tests/test_routing_api.py
+++ b/tests/test_routing_api.py
@@ -1182,14 +1182,10 @@ class RoutingApiTest(unittest.TestCase):
 
     @responses.activate
     def test_route_v8_multiple_via_points(self):
-        with codecs.open(
-            "testdata/models/routing_v8_response.json", mode="r", encoding="utf-8"
-        ) as f:
-            expectedResponse = f.read()
         responses.add(
             responses.GET,
             "https://router.hereapi.com/v8/routes",
-            expectedResponse,
+            "{}",
             status=200,
             match=[
                 responses.matchers.query_param_matcher(


### PR DESCRIPTION
Regarding `route_v8` and the use of `via` parameter:

When adding more than 10 via points, the last ones are ignored.

It comes from the fact that in that case, some `keys_for_manipulation` are substrings of others (ex: `"via1"` and `"via10"`).
When you replace the first one in the url, it also replaces a part of the second one, and so the replace does not work as expected (you end up with a `via0=` in the final url)

I just ensured that first keys can not be substrings of last ones.